### PR TITLE
added feature of remote base url for react snap

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "repository": {
     "url": "git@github.com:SvavaCapital/react-snap.git"
   },
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Zero-configuration framework-agnostic static prerendering for SPAs",
   "main": "index.js",
   "license": "MIT",

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -140,7 +140,8 @@ const crawl = async opt => {
     afterFetch,
     onEnd,
     publicPath,
-    sourceDir
+    sourceDir,
+    baseHostname
   } = opt;
   let shuttingDown = false;
   let streamClosed = false;
@@ -185,8 +186,11 @@ const crawl = async opt => {
     // we are converting both to string to be sure
     // Port can be null, therefore we need the null check
     const isOnAppPort = port && port.toString() === options.port.toString();
-
-    if (hostname === "localhost" && isOnAppPort && !uniqueUrls.has(newUrl) && !streamClosed) {
+    const isHostedCorrectly =
+      (options.remoteBaseUrl && hostname === baseHostname) ||
+      (hostname === "localhost" && isOnAppPort);
+    
+    if(isHostedCorrectly && !uniqueUrls.has(newUrl) && !streamClosed) {
       uniqueUrls.add(newUrl);
       enqued++;
       queue.write(newUrl);
@@ -263,7 +267,7 @@ const crawl = async opt => {
       }
     } else {
       // this message creates a lot of noise
-      // console.log(`🚧  skipping (${processed + 1}/${enqued}) ${route}`);
+      console.log(`🚧  skipping (${processed + 1}/${enqued}) ${route}`);
     }
     processed++;
     if (enqued === processed) {


### PR DESCRIPTION
Right now react-snap checks for localhost urls and create pre-rendered files for them. Sometimes we need to get pre-rendered files for specific remote url. To achieve this scenario I am adding a new key `remoteBaseUrl`. By passing this key one can get pre-rendered files in destination Directory for all urls passing through includes list.